### PR TITLE
Summary: Fixes #34 - cli-no-args test fails on python3

### DIFF
--- a/test_pimento.py
+++ b/test_pimento.py
@@ -306,7 +306,8 @@ def test_cli_script_use():
     p.expect_exact('usage: pimento [-h] [--pre TEXT] [--post TEXT] [--default-index INT]')
     p.expect_exact('[--indexed]')
     p.expect_exact('option [option ...]')
-    p.expect_exact('pimento: error: too few arguments')
+    p.expect_exact(['pimento: error: too few arguments',
+                    'pimento: error: the following arguments are required: option'])
 
 
 def test_cli_script_help():

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34
+
+[testenv]
+commands = py.test
+deps =
+    pytest
+    pexpect


### PR DESCRIPTION
## Problem:  
the CLI test where the user enters no options fails on python3.

## Analysis:
 the test expects "not enough args" as an error message from
argparse, but in python3, the parser actually errors about specific
arguments missing.  Updated the test to accept either the python 2 or
python 3 output for this condition.

## Testing: 
Existing tests caught failure, so no new tests were added.  Ran
tox.  All tests passed in configured environments.