### PR TITLE
Summary: Fixes #23 - make arrow keys work

### DIFF
--- a/pimento/__init__.py
+++ b/pimento/__init__.py
@@ -8,6 +8,13 @@ Make simple python cli menus!
 # import as _name so that they do not show up as part of the module
 import sys as _sys
 import argparse as _argparse
+try:
+    # just importing readline means that 'input' will use it.
+    # this is unpythonic, but I did not write the builtins.
+    import readline as _readline
+except ImportError:
+    # No readline.  Arrow support will be disabled
+    pass
 
 
 # [ GLOBALS ]
@@ -47,12 +54,19 @@ def _prompt(pre_prompt, items, post_prompt, default, indexed, stream):
         item_text = item_format.format(**components)
         item_text_list.append(item_text)
     # build full menu
-    menu_parts = [pre_prompt] + item_text_list + [post_prompt]
-    full_menu = '\n'.join(menu_parts)
+    menu_parts = [pre_prompt] + item_text_list
+    full_menu = '\n'.join(menu_parts) + '\n'
     stream.write(full_menu)
     stream.flush()
     # Get user response
-    response = _sys.stdin.readline().rstrip()
+    # - py 2/3 compatibility
+    get_input = input
+    try:
+        get_input = raw_input
+    except NameError:
+        pass
+    # - actuall get input
+    response = get_input(post_prompt)
     return response
 
 

--- a/test_pimento.py
+++ b/test_pimento.py
@@ -433,6 +433,24 @@ def test_search():
     p.expect_exact('dairy queen')
 
 
+def test_arrows():
+    p = pexpect.spawn('pimento foo bar', timeout=1)
+    p.expect_exact('Enter an option to continue: ')
+    p.send('oo')
+    p.sendline()
+    p.expect_exact('[!] "oo" does not match any of the valid choices.')
+    p.expect_exact('Enter an option to continue: ')
+    KEY_UP = '\x1b[A'
+    #KEY_DOWN = '\x1b[B'
+    #KEY_RIGHT = '\x1b[C'
+    KEY_LEFT = '\x1b[D'
+    p.send(KEY_UP)
+    p.expect_exact('oo')
+    p.send(KEY_LEFT*2)
+    p.sendline('f')
+    p.expect('\r\nfoo')
+
+
 # [ Manual Interaction ]
 if __name__ == '__main__':
     import argparse

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py27, py34
 
 [testenv]
-commands = py.test
+commands = py.test -vx
 deps =
     pytest
     pexpect


### PR DESCRIPTION
Problem: Arrow keys just added weird characters to the input line

Analysis: Use the readline library to provide arrow support

Testing: Added the test_arrows test case, which uses up and back arrows to modify
a previous entry and correct it.