### PR TITLE
Summary: fixes #46 - fuzzy matching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ cli menu with all the features
 * indexing
 * default selection
 * case-insensitivity
-* 'search' matching (vs 'match' matching)
+* 'fuzzy' matching
 
 .. code:: python
 
@@ -62,7 +62,7 @@ cli menu with all the features
     default_index=1,
     indexed=True,
     insensitive=True,
-    search=True
+    fuzzy=True
   )
 
 Prints:
@@ -90,8 +90,8 @@ features
 * `using indices`_
 * `deduplication`_
 * `case-insensitivity`_
-* `searching`_
 * `arrow keys`_
+* `fuzzy matching`_
 
 custom pre-prompt
 -----------------
@@ -320,29 +320,32 @@ Prints:
 
 Entering ``red`` will get you ``RED``, ``blue`` will get you ``Blue``, and ``GREEN`` will get you ``green``.
 
-searching
----------
+fuzzy matching
+--------------
 
-``menu`` will accept a ``search`` argument, which will make the menu search for the user input in the whole item string, rather than just at the start:
+``menu`` will accept a ``fuzzy`` argument, which will make the menu search for the words in the user input in the words of the item string,
+rather than just matching the user input from the start of the option:
 
 .. code:: python
 
     from pimento import menu
     result = menu(
-      ['RED bull', 'Blue bonnet', 'green giant'],
-      insensitive=True
+      ['a blue thing', 'one green thing'],
+      fuzzy=True
     )
 
 Prints:
 ::
 
     Options:
-      RED bull
-      Blue bonnet
-      green giant
+      a blue thing
+      one green thing
     Enter an option to continue: 
 
-Entering ``bull`` will return ``RED bull``.
+Entering ``thing n`` will return ``one green thing``.
+
+This method matches ``thing`` to both options (both contain the full word ``thing``), then matches ``n`` only to ``one green thing``,
+because that's the only option with an unmatched ``n`` (in both ``one`` and ``green``).
 
 arrow keys
 ----------
@@ -389,9 +392,7 @@ There is a standalone CLI tool of the same name (``pimento``), which is a wrappe
                             use them to choose.
       --insensitive, -I     Perform insensitive matching. Also drops any items
                             that case-insensitively match prior items.
-      --search, -s          search for the user input anywhere in the item
-                            strings, not just at the beginning.
-
+      --fuzzy, -f           search for the individual words in the user input anywhere in the item strings.
 
     The default for the post prompt is "Enter an option to continue: ". If
     --default-index is specified, the default option value will be printed in the
@@ -426,10 +427,13 @@ pimento has been tested on python 2.7.9 and 3.4.3 on OSX.  To test yourself:
     pip install tox
     tox
 
-API deprecation notice
-======================
+API deprecation notices
+=======================
 
-Prior to version v0.4.0, the signature for ``menu`` was:
+Prompt ordering
+---------------
+
+Prior to version 0.4.0, the signature for ``menu`` was:
 
 .. code:: python
 
@@ -444,3 +448,10 @@ In v0.4.0, the signature changed to:
 To ease transition of any users, there is special code in place to determine which order the caller is passing in ``items`` and ``pre_prompt``.  All pre-0.4.0 code should continue to work, but passing ``pre_prompt`` as the first argument is a deprecated use and should be discontinued.  Old code should be updated.  The compatibility mode will be discontinued soon, but definitely by 1.0.0.
 
 The API was changed to allow the simplest possible calling/use of the ``menu`` function.  The original signature was chosen because I thought that there wasn't a sensible default value, but "Options:" seems sensible enough for a generic default.
+
+Search matching
+---------------
+
+As of version 0.6.0, the ``search`` method of matching is deprecated.  It will be removed within a few releases, but definitely by v1.0.0.
+
+``fuzzy`` matching matches the same cases, and is more versatile.

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,9 @@
 envlist = py27, py34
 
 [testenv]
-commands = py.test -vx
+commands = py.test -n 8 -vx {posargs}
 deps =
     pytest
     pexpect
+    pytest-cache
+    pytest-xdist


### PR DESCRIPTION
Problem: search matching is too restrictive, and doesn't work well with
tab-completion via readline (see issue #27).

Analysis:
Use 'fuzzy' matching, where all of the user input words are
matched against the words in each option.  The method is:
* if an input word matches an item word exactly, count that as a match,
  and remove the word from both the user in put and the option, so that
  it is not matched again.
* if any remaining user input word is contained in any remaining option
  word, remove that partial word from the user input and the matching
  word from the option text.  Do this in order of longest partial to
  shortest.
* if there are no more items to match in the user input, then all of the
  user input has been matched, and the option being examined should be
  considered a match.

Deprecate the search command.

Testing: added two new tests: one for fuzzy matching, and one for
case-insensitive fuzzy matching.

Documentation: updated the docs to discuss 'fuzzy' matching and
deprecate the search command.