### PR TITLE
summary: fixes #48 - api deprecation broken link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ simple CLI menu
 * `cli`_
 * `installation`_
 * `testing`_
-* `API deprecation notice`_
+* `API deprecation notices`_
 
 examples
 ========


### PR DESCRIPTION
**problem:**
API deprecation link is broken

**analysis:**
link was to "API deprecation", but the section heading had been changed to "API deprecations", with an "s".  This broke the link.  Update the link.

**testing:**
check rendered page in own branch on github

**documentation:**
fix the doc link