### PR TITLE
Summary: fixes #43 - empty items allowed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,12 +51,14 @@ cli menu with all the features
 * default selection
 * case-insensitivity
 * 'fuzzy' matching
+* deduplication
+* removal of empty items
 
 .. code:: python
 
   from pimento import menu
   result = menu(
-    ['RED', 'Red', 'blue', 'green', 'grey', 'light URPLE'],
+    ['', 'RED', 'Red', 'blue', 'green', 'grey', 'green', 'light URPLE'],
     pre_prompt='Available colors:',
     post_prompt='Please select a color [{}]',
     default_index=1,
@@ -90,6 +92,8 @@ features
 * `using a default`_
 * `using indices`_
 * `deduplication`_
+* `removal of empty items`_
+* `strips trailing whitespace`_
 * `case-insensitivity`_
 * `arrow keys`_
 * `fuzzy matching`_
@@ -302,7 +306,57 @@ If you pass multiple matching items into ``menu``, it will deduplicate them for 
   [!] Please specify your choice further.
 
 You can't specify a choice any further in this case, so ``pimento`` deduplicates the list for you.
-If you expect your list of items not to need deduplication, you should check that prior to calling ``menu``.
+If you expect your list of items not to need deduplication, and you care about duplicates, you should check for them prior to calling ``menu``.
+
+The default index, if specified, will be used to select the default from the list prior to deduplication:
+::
+
+  pimento bar foo foo -d 2
+  Options:
+    bar
+    foo
+  Please select an option [foo]: <enter>
+
+In the above example, ``pimento`` prints 'foo' to stdout.
+
+removal of empty items
+----------------------
+
+If you pass empty items into ``menu``, it will remove them for you.  This is to prevent the following scenario:
+::
+
+  pimento ''
+  Options:
+  
+  Please select an option: <enter>
+  [!] an empty response is not valid.
+  Options:
+  
+  Please select an option: 
+
+You can't specify an empty choice, and an empty choice doesn't make sense anyway, so ``pimento`` removes them for you.
+If all you had was empty choices, the call will fail with a ValueError about the list being empty.
+If you expect your list of items not to need removal of empty items, and you care if there are any, you should check that prior to calling ``menu``.
+
+The default index, if specified, will be used to select the default from the list prior to removal of empty items:
+::
+
+  pimento '' bar foo -d 2
+  Options:
+    bar
+    foo
+  Please select an option [foo]: <enter>
+
+In the above example, ``pimento`` prints 'foo' to stdout.
+
+strips trailing whitespace
+--------------------------
+
+Trailing whitespace is stripped from each option passed in.
+A whitespace item is defined for ``pimento`` as it is by python - typically space, tab, newline, carriage return.
+
+* If stripping whitespace means that the item becomes a duplicate of another item, it will be removed according to the description in `deduplication`_.
+* If it means that the item becomes empty it is removed according to the description in `removal of empty items`_.
 
 case-insensitivity
 ------------------

--- a/test_pimento.py
+++ b/test_pimento.py
@@ -599,6 +599,51 @@ def test_functions_documented():
         assert func.__doc__, "{} not documented!".format(name)
 
 
+def test_empty_option_cli():
+    p = pexpect.spawn('pimento "" "" ""', timeout=1)
+    p.expect_exact('ERROR: The item list is empty.')
+    p = pexpect.spawn('pimento "" "a BLUE thing" "" "one GREEN thing" "" --fuzzy', timeout=1)
+    p.expect_exact('Options:')
+    p.expect_exact('  a BLUE thing')
+    p.expect_exact('  one GREEN thing')
+    p.expect_exact('Enter an option to continue: ')
+
+
+def test_empty_option_menu():
+    with pytest.raises(ValueError):
+        pimento.menu([''])
+
+
+def test_whitespace_option_menu():
+    with pytest.raises(ValueError):
+        pimento.menu(['', ' ', '\t', '\n', '\r  '])
+
+
+def test_pre_default_selection():
+    p = pexpect.spawn('pimento "" "RED" " " "red" "\n\t\r" "green" -Id 5', timeout=1)
+    p.expect_exact('Options:')
+    p.expect_exact('  RED')
+    p.expect_exact('  green')
+    p.expect_exact('Enter an option to continue [green]: ')
+
+
+def test_rstrip_items():
+    p = pexpect.spawn('pimento "red " "red  " "red\t"', timeout=1)
+    p.expect_exact('Options:')
+    p.expect_exact('  red')
+    p.expect_exact('Enter an option to continue: ')
+
+
+def test_empty_default_selection():
+    with pytest.raises(ValueError):
+        pimento.menu(['', 'foo'], default_index=0)
+
+
+def test_empty_default_selection_cli():
+    p = pexpect.spawn('pimento "" "foo" -d 0', timeout=1)
+    p.expect_exact('ERROR: The default index (0) points to an empty item.')
+
+
 # [ Manual Interaction ]
 if __name__ == '__main__':
     import argparse


### PR DESCRIPTION
**Problem**
Empty items were allowed, which could never be matched.

**Analysis**
The item list wasn't being checked for empty items, just iterability and
finiteness, and non-emptiness (as a list).

Adding a check after deduplication fixes the immediate problem, but
leaves the similar issue of all-whitespace items and trailing-whitespace
items.

Using python's 'rstrip' prior to deduplication and empty-item checking
takes care of both of those related issues.

As with deduplication, the rstripping and the empty-item removal is done
automatically.  The assumption is that the user does not actually want
to display these things, as it is nonsensical, so it is *safe* to remove
them.  Further, it is asserted that if the user cares about catching
these mistakes themselves, they can do so easily prior to calling the
menu API.  If this becomes a common use case, it will be a new feature
to add a --pedantic or --no-assumptions flag, or something like that.

Also, something missed prior was default selection when deduplication is
occurring.  Prior to this commit, if deduplication caused the default
selection to be out-of-bounds, an error would be thrown.  Now the
default selection is processed prior to deduplication, so the expected
value is preserved.

**Testing**
Added 7 new tests to cover rstripping, deduplication after rstripping,
empty removal after rstripping, early default-selection, and selection
of an empty default.

**Documentation**
Added documentation for the rstripping, empty item removal, and early
default selection logic.