### PR TITLE
Summary: Fixes #44 - partial matches

### DIFF
--- a/test_pimento.py
+++ b/test_pimento.py
@@ -651,6 +651,35 @@ def test_ctrl_c():
     p.expect_exact('CTRL-C detected. Exiting.')
 
 
+def test_partial_option():
+    p = pexpect.spawn('pimento foo "foo bar"', timeout=1)
+    p.expect_exact('Options:')
+    p.expect_exact('  foo')
+    p.expect_exact('  foo bar')
+    p.expect_exact('Enter an option to continue: ')
+    p.sendline('foo')
+    p.expect_exact('foo')
+    index = p.expect_exact(['[!]', 'foo'])
+    assert index != 0, "Got unexpected warning"
+
+
+def test_partial_fuzzy_option():
+    p = pexpect.spawn('pimento foo "foo bar" "foo bar baz" -f', timeout=1)
+    p.expect_exact('Options:')
+    p.expect_exact('  foo')
+    p.expect_exact('  foo bar')
+    p.expect_exact('  foo bar baz')
+    p.expect_exact('Enter an option to continue: ')
+    p.sendline('oo')
+    p.expect_exact('[!] "oo" matches multiple choices:')
+    p.expect_exact('[!]   foo')
+    p.expect_exact('[!]   foo bar')
+    p.expect_exact('[!]   foo bar baz')
+    p.expect_exact('[!] Please specify your choice further.')
+    p.sendline('bar foo')
+    p.expect_exact('foo bar baz')
+
+
 # [ Manual Interaction ]
 if __name__ == '__main__':
     import argparse


### PR DESCRIPTION
**problem**
If an option is a subset of another option (like the following):
 * foo
 * foo bar

There is no way to select the partial option.

**analysis**
Add checks for exact matches with the options.  if the user response
exactly matches an option, use that option.

Add checks to verify this even in the case of fuzzy matching, but
restrict the definition of "exact" match to be exactly matching whole
words, not partial words, as the user may further elaborate to include
partials or words from the longer options.

**testing**
Added two new tests

**documentation**
as I believe this is the expected behavior, no new documentation is
needed.