### PR TITLE
Summary: Fixes #22 - pipe support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -435,7 +435,7 @@ There is a standalone CLI tool of the same name (``pimento``), which is a wrappe
     pimento --help
     usage: pimento [-h] [--pre TEXT] [--post TEXT] [--default-index INT]
                    [--indexed]
-                   option [option ...]
+                   [option ...]
 
     Present the user with a simple CLI menu, and return the option chosen. The
     menu is presented via stderr. The output is printed to stdout for piping.
@@ -459,6 +459,15 @@ There is a standalone CLI tool of the same name (``pimento``), which is a wrappe
     The default for the post prompt is "Enter an option to continue: ". If
     --default-index is specified, the default option value will be printed in the
     post prompt as well.
+
+On \*nix, the CLI tool is capable of taking options from a pipe, like so:
+::
+
+  echo -e 'foo\nbar' | pimento
+  Options:
+    foo
+    bar
+  Enter an option to continue:
 
 
 installation

--- a/pimento/__init__.py
+++ b/pimento/__init__.py
@@ -8,6 +8,7 @@ Make simple python cli menus!
 # import as _name so that they do not show up as part of the module
 import sys as _sys
 import argparse as _argparse
+import os.path as _path
 try:
     # just importing readline means that 'input' will use it.
     # this is unpythonic, but I did not write the builtins.
@@ -405,7 +406,7 @@ def _cli():
     parser.add_argument(
         'option',
         help='The option(s) to present to the user.',
-        nargs='+'
+        nargs='*'
     )
     parser.add_argument(
         '--pre', '-p',
@@ -449,6 +450,15 @@ def _cli():
     args.search = '--search' in unknown or '-s' in unknown
     # argparse nargs is awkward.  Translate to be a proper plural.
     options = args.option
+    # read more options from stdin if there are are any
+    # but only if we're on a 'nix system with tty's
+    tty = '/dev/tty'
+    if not _sys.stdin.isatty() and _path.exists(tty):
+        options += [l.rstrip() for l in _sys.stdin]
+        # switch to the main tty
+        # this solution (to being interactive after reading from pipe)
+        # comes from: https://stackoverflow.com/questions/6312819/pipes-and-prompts-in-python-cli-scripts
+        _sys.stdin = open(tty)
     # show the menu
     try:
         result = menu(

--- a/test_pimento.py
+++ b/test_pimento.py
@@ -304,19 +304,11 @@ def test_module_contents():
     assert public_attributes == ['menu']
 
 
-def test_cli_script_use():
-    p = pexpect.spawn('pimento', timeout=1)
-    p.expect_exact('usage: pimento [-h] [--pre TEXT] [--post TEXT] [--default-index INT]')
-    p.expect_exact('[--indexed]')
-    p.expect_exact('option [option ...]')
-    p.expect_exact(['pimento: error: too few arguments',
-                    'pimento: error: the following arguments are required: option'])
-
-
 def test_cli_script_help():
     expected_help_text = '''usage: pimento [-h] [--pre TEXT] [--post TEXT] [--default-index INT]
                [--indexed]
-               option [option ...]
+               [option [option ...]]
+
 
 Present the user with a simple CLI menu, and return the option chosen. The
 menu is presented via stderr. The output is printed to stdout for piping.
@@ -678,6 +670,14 @@ def test_partial_fuzzy_option():
     p.expect_exact('[!] Please specify your choice further.')
     p.sendline('bar foo')
     p.expect_exact('foo bar baz')
+
+
+def test_piping_to_cli():
+    p = pexpect.spawn('bash', args = ['-c', 'echo -e "hello\ngoodbye" | pimento'], timeout=1)
+    p.expect_exact('Options:')
+    p.expect_exact('  hello')
+    p.expect_exact('  goodbye')
+    p.expect_exact('Enter an option to continue: ')
 
 
 # [ Manual Interaction ]


### PR DESCRIPTION
**problem**
It would be nice to have the ability to pass options in via a pipe.

**analysis**
This is easy on all platforms, but the problem is that then you can't
have interactive input afterwards, which is kind of necessary.

On 'nix environments, you can re-attach to /dev/tty.

On windows environments, you might be able to connect to a COM.
https://stackoverflow.com/questions/19172563/how-do-i-accept-piped-input-and-then-user-prompted-input-in-a-python-script

I don't have any windows test environments, so I'm making it unix only,
since that's all I can verify.

**testing**
added one test for piping.
removed a test for showing the usage message when entering no args on
the cli, which now waits for piped args, and then yells about no items.

**documentation**
added documentation describing the piping feature in the CLI section.