### PR TITLE
Summary:  Fixes #61 - remove deprecated features

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,6 @@ Use python? Use the CLI? Ever prompt a user to select an option? I have just the
 * `cli`_
 * `installation`_
 * `testing`_
-* `API deprecation notices`_
 
 examples
 ========
@@ -516,31 +515,3 @@ pimento has been tested on python 2.7.9 and 3.4.3 on OSX.  To test yourself:
     pip install tox
     tox
 
-API deprecation notices
-=======================
-
-Prompt ordering
----------------
-
-Prior to version 0.4.0, the signature for ``menu`` was:
-
-.. code:: python
-
-    def menu(pre_prompt, items, post_prompt=DEFAULT, default_index=None, indexed=False):
-
-In v0.4.0, the signature changed to:
-
-.. code:: python
-
-    def menu(items, pre_prompt=DEFAULT, post_prompt=DEFAULT, default_index=None, indexed=False):
-
-To ease transition of any users, there is special code in place to determine which order the caller is passing in ``items`` and ``pre_prompt``.  All pre-0.4.0 code should continue to work, but passing ``pre_prompt`` as the first argument is a deprecated use and should be discontinued.  Old code should be updated.  The compatibility mode will be discontinued soon, but definitely by 1.0.0.
-
-The API was changed to allow the simplest possible calling/use of the ``menu`` function.  The original signature was chosen because I thought that there wasn't a sensible default value, but "Options:" seems sensible enough for a generic default.
-
-Search matching
----------------
-
-As of version 0.6.0, the ``search`` method of matching is deprecated.  It will be removed within a few releases, but definitely by v1.0.0.
-
-``fuzzy`` matching matches the same cases, and is more versatile.

--- a/pimento/__init__.py
+++ b/pimento/__init__.py
@@ -289,7 +289,7 @@ def _exact_match(response, matches, insensitive, fuzzy):
         return None
 
 
-def _check_response(response, items, default, indexed, stream, insensitive, search, fuzzy):
+def _check_response(response, items, default, indexed, stream, insensitive, fuzzy):
     '''Check the response against the items'''
     # Set selection
     selection = None
@@ -311,8 +311,6 @@ def _check_response(response, items, default, indexed, stream, insensitive, sear
         if fuzzy:
             matches = _get_fuzzy_matches(response, items)
         # if insensitive, lowercase the comparison
-        elif search:
-            matches = [i for i in items if response in i]
         else:
             matches = [i for i in items if i.startswith(response)]
         # re-sensivitize if necessary
@@ -456,9 +454,7 @@ def _cli():
         action='store_true'
     )
     # parse options
-    args, unknown = parser.parse_known_args()
-    # set deprecated search option
-    args.search = '--search' in unknown or '-s' in unknown
+    args = parser.parse_args()
     # argparse nargs is awkward.  Translate to be a proper plural.
     options = args.option
     # set the stream
@@ -485,7 +481,6 @@ def _cli():
             default_index=args.default_index,
             indexed=args.indexed,
             insensitive=args.insensitive,
-            search=args.search,
             fuzzy=args.fuzzy,
             stream=stream
         )
@@ -523,7 +518,7 @@ def _dedup(items, insensitive):
 
 # [ Public API ]
 def menu(items, pre_prompt="Options:", post_prompt=_NO_ARG, default_index=None, indexed=False,
-         stream=_sys.stderr, insensitive=False, search=False, fuzzy=False, quiet=False):
+         stream=_sys.stderr, insensitive=False, fuzzy=False, quiet=False):
     '''
     Prompt with a menu.
 
@@ -537,7 +532,6 @@ def menu(items, pre_prompt="Options:", post_prompt=_NO_ARG, default_index=None, 
             can be reserved for program output rather than interactive menu output.
         insensitive -  allow insensitive matching.  Also drops items which case-insensitively match
           prior items.
-        search -  [deprecated] search for the user input anwhere in the item strings, not just at the beginning.
         fuzzy -  search for the individual words in the user input anywhere in the item strings.
 
     Specifying a default index:
@@ -555,11 +549,6 @@ def menu(items, pre_prompt="Options:", post_prompt=_NO_ARG, default_index=None, 
     Return:
         result -  The full text of the unambiguously selected item.
     '''
-    # deprecated use: pre_promt first, items second
-    if isinstance(items, str) and not isinstance(pre_prompt, str):
-        swap = items
-        items = pre_prompt
-        pre_prompt = swap
     # arg checking
     _check_prompts(pre_prompt, post_prompt)
     _check_items(items)
@@ -624,7 +613,7 @@ def menu(items, pre_prompt="Options:", post_prompt=_NO_ARG, default_index=None, 
             # Prompt and get response
             response = _prompt(pre_prompt, items, actual_post_prompt, default, indexed, stream)
             # validate response
-            selection = _check_response(response, items, default, indexed, stream, insensitive, search, fuzzy)
+            selection = _check_response(response, items, default, indexed, stream, insensitive, fuzzy)
             # NOTE: acceptable response logic is purposely verbose to be clear about the semantics.
             if selection is not None:
                 acceptable_response_given = True

--- a/test_pimento.py
+++ b/test_pimento.py
@@ -179,29 +179,29 @@ def test_indexed_numbers():
 def test_default_not_in_range():
     # negative
     with pytest.raises(ValueError):
-        pimento.menu("Yes/No?", ['yes', 'no'], "Please select one [{}]: ", default_index=-1)
+        pimento.menu(['yes', 'no'], "Yes/No?", "Please select one [{}]: ", default_index=-1)
     # past range
     with pytest.raises(ValueError):
-        pimento.menu("Yes/No?", ['yes', 'no'], "Please select one [{}]: ", default_index=2)
+        pimento.menu(['yes', 'no'], "Yes/No?", "Please select one [{}]: ", default_index=2)
 
 
 def test_default_incorrect_type():
     # float
     with pytest.raises(TypeError):
-        pimento.menu("Yes/No?", ['yes', 'no'], "Please select one [{}]: ", default_index=1.5)
+        pimento.menu(['yes', 'no'], "Yes/No?", "Please select one [{}]: ", default_index=1.5)
 
 
 def test_no_items():
     # try to create a menu with no items
     with pytest.raises(ValueError):
-        pimento.menu("Yes/No?", [], "Please select one: ")
+        pimento.menu([], "Yes/No?", "Please select one: ")
 
 
 def test_bad_items_type():
     # try to create a menu with bad items
     # with a non-iterable
     with pytest.raises(TypeError):
-        pimento.menu("Yes/No?", 6, "Please select one: ")
+        pimento.menu(6, "Yes/No?", "Please select one: ")
     # with an unbounded iterable
     def generator():
         x = 0
@@ -209,7 +209,7 @@ def test_bad_items_type():
             yield x
             x += 1
     with pytest.raises(TypeError):
-        pimento.menu("Yes/No?", generator(), "Please select one: ")
+        pimento.menu(generator(), "Yes/No?", "Please select one: ")
 
 
 def test_iterable_items():
@@ -283,7 +283,7 @@ def test_post_prompt_not_string():
     # test for https://github.com/toejough/pimento/issues/15
     # test post prompt is int
     try:
-        pimento.menu("pre-prompt", [1,2,3], 5)
+        pimento.menu([1,2,3], "pre-prompt", 5)
     except Exception as e:
         assert "pre_prompt" not in e.args[0]
 
@@ -303,7 +303,6 @@ def test_menu_documentation():
             can be reserved for program output rather than interactive menu output.
         insensitive -  allow insensitive matching.  Also drops items which case-insensitively match
           prior items.
-        search -  [deprecated] search for the user input anwhere in the item strings, not just at the beginning.
         fuzzy -  search for the individual words in the user input anywhere in the item strings.
 
     Specifying a default index:
@@ -441,36 +440,6 @@ def test_insensitive_deduplication():
     p.expect_exact('Options:')
     p.expect_exact('  Foo')
     p.expect_exact('Enter an option to continue: ')
-
-
-def test_search():
-    p = pexpect.spawn('pimento "pizza hut" "taco bell" "dairy queen" --search', timeout=1)
-    p.expect_exact('Options:')
-    p.expect_exact('  pizza hut')
-    p.expect_exact('  taco bell')
-    p.expect_exact('  dairy queen')
-    p.expect_exact('Enter an option to continue: ')
-    p.sendline("queen")
-    p.expect_exact('dairy queen')
-    p = pexpect.spawn('pimento "pizza hut" "taco bell" "dairy queen" --search', timeout=1)
-    p.expect_exact('Options:')
-    p.expect_exact('  pizza hut')
-    p.expect_exact('  taco bell')
-    p.expect_exact('  dairy queen')
-    p.expect_exact('Enter an option to continue: ')
-    p.sendline("e")
-    p.expect_exact('[!] "e" matches multiple choices:')
-    p.expect_exact('[!]   taco bell')
-    p.expect_exact('[!]   dairy queen')
-    p.expect_exact('[!] Please specify your choice further.')
-    p = pexpect.spawn('pimento "pizza hut" "taco bell" "dairy queen" --search', timeout=1)
-    p.expect_exact('Options:')
-    p.expect_exact('  pizza hut')
-    p.expect_exact('  taco bell')
-    p.expect_exact('  dairy queen')
-    p.expect_exact('Enter an option to continue: ')
-    p.sendline("Queen")
-    p.expect_exact('dairy queen')
 
 
 def test_arrows():
@@ -934,19 +903,19 @@ if __name__ == '__main__':
                         action='store_true')
     args = parser.parse_args()
     if args.indexed_numbers:
-        result = pimento.menu("Select one of the following:", ['100', '200', '300'], "Please select by index or value: ", indexed=True)
+        result = pimento.menu(['100', '200', '300'], "Select one of the following:", "Please select by index or value: ", indexed=True)
     elif args.tuple:
-        result = pimento.menu("Select one of the following:", ('100', '200', '300'), "Please select: ")
+        result = pimento.menu(('100', '200', '300'), "Select one of the following:", "Please select: ")
     elif args.string:
         result = pimento.menu('abc', "Select one of the following:", "Please select: ")
     elif args.dictionary:
-        result = pimento.menu("Select one of the following:", {'key1': 'v1', 'key2': 'v2'}, "Please select: ")
+        result = pimento.menu({'key1': 'v1', 'key2': 'v2'}, "Select one of the following:", "Please select: ")
     elif args.set:
-        result = pimento.menu("Select one of the following:", set([1, 2]), "Please select: ")
+        result = pimento.menu(set([1, 2]), "Select one of the following:", "Please select: ")
     elif args.pre_only:
-        result = pimento.menu("Select one of the following:", [1, 2])
+        result = pimento.menu([1, 2], "Select one of the following:", )
     elif args.pre_only_default:
-        result = pimento.menu("Select one of the following:", [1, 2], default_index=0)
+        result = pimento.menu([1, 2], "Select one of the following:", default_index=0)
     elif args.list_only:
         result = pimento.menu([1, 2])
     print('Result is {}'.format(result))


### PR DESCRIPTION
**Problem:**
Deprecated features (search-mode and pre-prompt as the first arg to menu) were cluttering the code and tests.

**Analysis:**
Remove the deprecated features, the tests for them, and the
documentation for them.

**Testing:**
Removed the tests for search-mode.
Updated tests which used pre-prompt as the first arg to send the
pre-prompt as the second arg.

**Documentation:**
Removed the documentation for the deprecated features.