### PR TITLE
Summary: fixes #68 - add contribution guidelines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ Use python? Use the CLI? Ever prompt a user to select an option? I have just the
 * `cli`_
 * `installation`_
 * `testing`_
+* `contribution`_
 
 examples
 ========
@@ -515,3 +516,39 @@ pimento has been tested on python 2.7.9 and 3.4.3 on OSX.  To test yourself:
     pip install tox
     tox
 
+contribution
+============
+
+Contributions welcome!  See the issues for current things that need to be addressed.
+
+When you contribute, please:
+
+* Run the tests before you change things, to make sure that you have a good version downloaded.  They should all pass.
+* Add sufficient tests to exercise the new behavior you're adding.
+* Run those before you push.
+* Add sufficient documentation to explain your changed behavior.
+* Use the below template in your final commit.
+
+contribution template
+---------------------
+
+I use SPATD.  Spatted?  Spatd?  I don't know, it doesn't make a great pronouncable acronym, but it's a great way to cover all the angles for a given change to the tool.
+::
+
+  Summary: <a one-line summary, which includes text to close the issue the commit addresses.>
+  
+  **Problem:**
+  <Describe the problem you are solving.  This should generally be a summary of the issue.>
+  
+  **Analysis:**
+  <Analysis of the problem, such as root-cause-analysis of the problem.>
+  <Analysis of the solution, such as what is the chosen solution and why.>
+  <Any other analysis/thoughts about this issue/solution.>
+  
+  **Testing:**
+  <What testing was performed.  Preferably automated tests.>
+  <If none, an explanation of why none was performed/added.>
+  
+  **Documentation:**
+  <What documentation was added.>
+  <If none, an explanation of why none was added.>


### PR DESCRIPTION
**Problem:**
No contribution guidelines

**Analysis:**
Add some.

**Testing:**
None - it's very difficult to automatically test the contribution guidelines because of the semantic nature of things like adding tests, adding documentation, and writing in good English.

**Documentation:**
Added contributions section to the readme